### PR TITLE
Fix for 11.0.2

### DIFF
--- a/uGain_Rep/uGain_Rep.lua
+++ b/uGain_Rep/uGain_Rep.lua
@@ -26,8 +26,13 @@ local function uRep_StandingText(standingId)
 end
 
 local function uRep_ReportFaction(factionIndex)
-    local factionData = C_Reputation.GetFactionDataByIndex(factionIndex)
-    local name, standingId, barMin, barMax, currentRep, isHeader = factionData.name, factionData.reaction, factionData.currentReactionThreshold, factionData.nextReactionThreshold, factionData.currentStanding, factionData.isHeader
+    if GetFactionInfo then
+        local name, _, standingId, barMin, barMax, currentRep, _, _, isHeader = GetFactionInfo(factionIndex)
+    else
+        local factionData = C_Reputation.GetFactionDataByIndex(factionIndex)
+        local name, standingId, barMin, barMax, currentRep, isHeader = factionData.name, factionData.reaction, factionData.currentReactionThreshold, factionData.nextReactionThreshold, factionData.currentStanding, factionData.isHeader
+    end
+    
     if isHeader then
         return nil
     end
@@ -81,11 +86,19 @@ end
 
 local function uRep_LoadFactions()
     local oldFactionCount = FactionCount
-    FactionCount = C_Reputation.GetNumFactions()
+    if GetNumFactions then
+        FactionCount = GetNumFactions()
+    else
+        FactionCount = C_Reputation.GetNumFactions()
+    end
 
     for i = 1, FactionCount do
-        local factionData = C_Reputation.GetFactionDataByIndex(i)
-        local name, standingId, barMax, currentRep, isHeader = factionData.name, factionData.reaction, factionData.nextReactionThreshold, factionData.currentStanding, factionData.isHeader
+        
+        if GetFactionInfo then
+            local name, _, standingId, _, barMax, currentRep, _, _, isHeader = GetFactionInfo(i)
+        else
+            local factionData = C_Reputation.GetFactionDataByIndex(i)
+            local name, standingId, barMax, currentRep, isHeader = factionData.name, factionData.reaction, factionData.nextReactionThreshold, factionData.currentStanding, factionData.isHeader        end
         local oldFaction = Factions[name]
         if oldFaction == nil and oldFactionCount > 0 and (not isHeader) then
             local factionChangeMessage = "Faction " .. uC(name, C.yellow) .. " found at " .. " " ..
@@ -101,7 +114,13 @@ local function uRep_LoadFactions()
 end
 
 local function uRep_ScanAndReport()
-    local currentFactionCount = C_Reputation.GetNumFactions()
+    
+    if GetNumFactions then
+        local currentFactionCount = GetNumFactions()
+    else
+        local currentFactionCount = C_Reputation.GetNumFactions()
+    end
+    
     if (currentFactionCount ~= FactionCount) then
         return uRep_LoadFactions()
     end

--- a/uGain_Rep/uGain_Rep.lua
+++ b/uGain_Rep/uGain_Rep.lua
@@ -26,7 +26,8 @@ local function uRep_StandingText(standingId)
 end
 
 local function uRep_ReportFaction(factionIndex)
-    local name, _, standingId, barMin, barMax, currentRep, _, _, isHeader = GetFactionInfo(factionIndex)
+    local factionData = C_Reputation.GetFactionDataByIndex(factionIndex)
+    local name, standingId, barMin, barMax, currentRep, isHeader = factionData.name, factionData.reaction, factionData.currentReactionThreshold, factionData.nextReactionThreshold, factionData.currentStanding, factionData.isHeader
     if isHeader then
         return nil
     end
@@ -80,10 +81,11 @@ end
 
 local function uRep_LoadFactions()
     local oldFactionCount = FactionCount
-    FactionCount = GetNumFactions()
+    FactionCount = C_Reputation.GetNumFactions()
 
     for i = 1, FactionCount do
-        local name, _, standingId, _, barMax, currentRep, _, _, isHeader = GetFactionInfo(i)
+        local factionData = C_Reputation.GetFactionDataByIndex(i)
+        local name, standingId, barMax, currentRep, isHeader = factionData.name, factionData.reaction, factionData.nextReactionThreshold, factionData.currentStanding, factionData.isHeader
         local oldFaction = Factions[name]
         if oldFaction == nil and oldFactionCount > 0 and (not isHeader) then
             local factionChangeMessage = "Faction " .. uC(name, C.yellow) .. " found at " .. " " ..
@@ -99,7 +101,7 @@ local function uRep_LoadFactions()
 end
 
 local function uRep_ScanAndReport()
-    local currentFactionCount = GetNumFactions()
+    local currentFactionCount = C_Reputation.GetNumFactions()
     if (currentFactionCount ~= FactionCount) then
         return uRep_LoadFactions()
     end

--- a/uGain_Rep/uGain_Rep.lua
+++ b/uGain_Rep/uGain_Rep.lua
@@ -26,11 +26,12 @@ local function uRep_StandingText(standingId)
 end
 
 local function uRep_ReportFaction(factionIndex)
+    local name, standingId, barMin, barMax, currentRep, isHeader
     if GetFactionInfo then
-        local name, _, standingId, barMin, barMax, currentRep, _, _, isHeader = GetFactionInfo(factionIndex)
+        name, _, standingId, barMin, barMax, currentRep, _, _, isHeader = GetFactionInfo(factionIndex)
     else
         local factionData = C_Reputation.GetFactionDataByIndex(factionIndex)
-        local name, standingId, barMin, barMax, currentRep, isHeader = factionData.name, factionData.reaction, factionData.currentReactionThreshold, factionData.nextReactionThreshold, factionData.currentStanding, factionData.isHeader
+        name, standingId, barMin, barMax, currentRep, isHeader = factionData.name, factionData.reaction, factionData.currentReactionThreshold, factionData.nextReactionThreshold, factionData.currentStanding, factionData.isHeader
     end
     
     if isHeader then
@@ -93,12 +94,13 @@ local function uRep_LoadFactions()
     end
 
     for i = 1, FactionCount do
-        
+        local name, standingId, barMax, currentRep, isHeader
         if GetFactionInfo then
-            local name, _, standingId, _, barMax, currentRep, _, _, isHeader = GetFactionInfo(i)
+            name, _, standingId, _, barMax, currentRep, _, _, isHeader = GetFactionInfo(i)
         else
             local factionData = C_Reputation.GetFactionDataByIndex(i)
-            local name, standingId, barMax, currentRep, isHeader = factionData.name, factionData.reaction, factionData.nextReactionThreshold, factionData.currentStanding, factionData.isHeader        end
+            name, standingId, barMax, currentRep, isHeader = factionData.name, factionData.reaction, factionData.nextReactionThreshold, factionData.currentStanding, factionData.isHeader
+        end
         local oldFaction = Factions[name]
         if oldFaction == nil and oldFactionCount > 0 and (not isHeader) then
             local factionChangeMessage = "Faction " .. uC(name, C.yellow) .. " found at " .. " " ..
@@ -114,11 +116,11 @@ local function uRep_LoadFactions()
 end
 
 local function uRep_ScanAndReport()
-    
+    local currentFactionCount
     if GetNumFactions then
-        local currentFactionCount = GetNumFactions()
+        currentFactionCount = GetNumFactions()
     else
-        local currentFactionCount = C_Reputation.GetNumFactions()
+        currentFactionCount = C_Reputation.GetNumFactions()
     end
     
     if (currentFactionCount ~= FactionCount) then


### PR DESCRIPTION
I really loved this addon for classic and added it to my retail addon list. Haven't had any issues for all of Dragonflight (besides uGain Skill obviously so I just disable lol) but with 11.0.2, blizz removed a few depreciated API calls in favor for namespaced versions.

I'm not sure if they did the same thing in classic yet so I implemented the retail changes and made them backwards compatible so they won't cause issues in classic / SoD.